### PR TITLE
CHORE: 리뷰어 자동 할당을 위한 CODEOWNERS 파일 추가

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @prgmd @uridonget @leedonggyu1848


### PR DESCRIPTION
리뷰어 자동 할당을 위한 사전준비입니다